### PR TITLE
docs: commit PDFs to repo and add README.md #4

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ on:
       - '.github/workflows/docs.yml'
 
 jobs:
-  build-pdfs:
+  build:
     runs-on: ubuntu-latest
     container:
       image: pandoc/extra:latest
@@ -38,3 +38,24 @@ jobs:
           name: vks-lab-docs
           path: docs/*.pdf
           retention-days: 90
+
+  commit:
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download PDFs
+        uses: actions/download-artifact@v4
+        with:
+          name: vks-lab-docs
+          path: docs/
+
+      - name: Commit PDFs
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "docs: regenerate PDFs [skip ci]"
+          file_pattern: "docs/*.pdf"

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-# Generated PDFs
-docs/*.pdf

--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# VKS Lab
+
+VMware Kubernetes Service (VKS) lab environment — infrastructure-as-documentation for a home lab running vSphere with Tanzu.
+
+## Documentation
+
+| Document | Description | PDF |
+|----------|-------------|-----|
+| [Conceptual Design](docs/conceptual-design.md) | Purpose, objectives, and high-level architecture | [PDF](docs/conceptual-design.pdf) |
+| [Logical Design](docs/logical-design.md) | Architecture overview and service topology | [PDF](docs/logical-design.pdf) |
+| [Physical Design](docs/physical-design.md) | VLANs, subnets, and hardware layout | [PDF](docs/physical-design.pdf) |
+| [Delivery Guide](docs/deliver.md) | Step-by-step deployment instructions | [PDF](docs/deliver.pdf) |
+| [Operations Guide](docs/operate.md) | Standard operating procedures and troubleshooting | [PDF](docs/operate.pdf) |
+
+## Getting Started
+
+Start with the [Delivery Guide](docs/deliver.md) for deployment instructions.
+
+## Generating PDFs Locally
+
+Requires [Pandoc](https://pandoc.org/) with XeLaTeX and the [Eisvogel](https://github.com/Wandmalfarbe/pandoc-latex-template) template:
+
+```bash
+docker run --rm -v "$(pwd):/data" pandoc/extra:latest \
+  docs/conceptual-design.md -o docs/conceptual-design.pdf \
+  --template eisvogel --pdf-engine=xelatex --toc --toc-depth=3 --number-sections \
+  --metadata-file=docs/metadata/design.yaml
+```
+
+PDFs are also generated automatically by CI on every push to `main` and committed back to the repo.


### PR DESCRIPTION
## Summary

- Split CI workflow into `build` + `commit` jobs so generated PDFs are committed back to the repo on pushes to main
- Use `stefanzweifel/git-auto-commit-action@v5` with `[skip ci]` to prevent infinite workflow loops
- Remove `docs/*.pdf` from `.gitignore` so PDFs are tracked
- Add `README.md` with documentation table linking all 5 docs (markdown + PDF) and local PDF generation instructions

## Test plan

- [ ] Push to main triggers CI
- [ ] CI generates PDFs and commits them to `docs/`
- [ ] `[skip ci]` prevents infinite re-triggering
- [ ] README.md renders on GitHub with clickable links to all docs
- [ ] PDF links in README work once CI has committed the files